### PR TITLE
Add parameter to avoid post jdk8 javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,9 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
                 <configuration>
+                     <!-- The following doclint line is a temporary hack to avoid javadoc errors that 
+                          appear following jdk-8.  Ultimately these warnings and errors should be resolved. -->
+                     <additionalparam>-Xdoclint:none</additionalparam> 
 		     <docfilessubdirs>true</docfilessubdirs>
                      <groups>
                          <group>


### PR DESCRIPTION
@kwsutter This change is to avoid over 100 javadoc errors that are new to java8 in the jaxr code.  These will need to be fixed at some point in the future but I don't want that to hold up the CI/CD release.  See https://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html