### PR TITLE
remove version from Spec document header

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -142,7 +142,7 @@
                     <sourceDocumentName>xml-registries-spec.adoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>
-                        <revnumber>${project.version}</revnumber>
+                        <revnumber>${spec.version}</revnumber>
                         <revremark>${status}</revremark>
                         <revdate>${revisiondate}</revdate>
                     </attributes>

--- a/spec/src/main/asciidoc/xml-registries-spec.adoc
+++ b/spec/src/main/asciidoc/xml-registries-spec.adoc
@@ -2,7 +2,7 @@
 // Copyright (c) 2017, 2019 Contributors to the Eclipse Foundation
 //
 
-= Jakarta XML Registries 1.0
+= Jakarta XML Registries
 :authors: Jakarta XML Registries Team, https://projects.eclipse.org/projects/ee4j.jakartaee-stable
 :email: https://dev.eclipse.org/mailman/listinfo/jakartaee-stable-dev
 :version-label!:


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Removed the version from the Spec document header.  And, modified the pom to use the spec.version instead of project.version for the generation of the Spec.